### PR TITLE
improved tests for birthday problem

### DIFF
--- a/augsburg/exercises/BirthdayProblem/BirthdayProblem.ipynb
+++ b/augsburg/exercises/BirthdayProblem/BirthdayProblem.ipynb
@@ -29,7 +29,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "metadata": {
     "nbgrader": {
      "grade": false,
@@ -75,7 +75,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": null,
    "metadata": {
     "nbgrader": {
      "grade": true,
@@ -95,7 +95,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": null,
    "metadata": {
     "nbgrader": {
      "grade": true,
@@ -108,6 +108,11 @@
    },
    "outputs": [],
    "source": [
+    "random.seed(42)\n",
+    "equal_birthdays(10)\n",
+    "random_number = random.randint(1, 100000)\n",
+    "assert random_number != 3479, 'It looks like you are generating twice as many random numbers as needed.'\n",
+    "assert random_number == 11396, 'The number of dates generated does not seem to fit the number of persons.'\n",
     "for seed, result in ((42, False), (192347, True)):\n",
     "    random.seed(seed)\n",
     "    assert equal_birthdays(20) == result, 'Your function appears to return an incorrect result.'"
@@ -122,7 +127,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {
     "nbgrader": {
      "grade": false,
@@ -164,7 +169,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": null,
    "metadata": {
     "nbgrader": {
      "grade": true,
@@ -184,7 +189,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 24,
+   "execution_count": null,
    "metadata": {
     "nbgrader": {
      "grade": true,
@@ -198,8 +203,8 @@
    "outputs": [],
    "source": [
     "random.seed(42)\n",
-    "for npersons, result in ((10, 0.1221), (20, 0.417), (30, 0.7026)):\n",
-    "    assert abs(probability_equal_birthdays(npersons, 10000)-result) < 0.0001, (\n",
+    "for npersons, result in ((10, 0.11705), (20, 0.41171), (30, 0.70778)):\n",
+    "    assert abs(probability_equal_birthdays(npersons, 100000)-result) < 0.0001, (\n",
     "        'Your function appears to return an incorrect result.')"
    ]
   },
@@ -212,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": null,
    "metadata": {
     "nbgrader": {
      "grade": true,
@@ -223,21 +228,9 @@
      "solution": true
     }
    },
-   "outputs": [
-    {
-     "data": {
-      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAXcAAAD8CAYAAACMwORRAAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAALEgAACxIB0t1+/AAAADl0RVh0U29mdHdhcmUAbWF0cGxvdGxpYiB2ZXJzaW9uIDMuMC4zLCBodHRwOi8vbWF0cGxvdGxpYi5vcmcvnQurowAAIABJREFUeJzt3Xl8VNX9//HXh5CFbGxJAIEQVgFRtsjmWoQWl4r2i0VwwVZEa12q3axaq9a239pFu6AWrRsVUVErWi1ahepXBQk7AQIBAglbFgKEhOzn90dGfzEiGWGSO8v7+XjkMXPvHCef88idN8cz955rzjlERCS8tPG6ABERCTyFu4hIGFK4i4iEIYW7iEgYUriLiIQhhbuISBhSuIuIhCGFu4hIGFK4i4iEobZe/eKUlBSXkZHh1a8XEQlJK1asKHbOpTbXzrNwz8jIICsry6tfLyISksxshz/tNC0jIhKGFO4iImFI4S4iEoaaDXcze9LMCs1s/Ze8bmb2ZzPLNbO1ZjYi8GWKiMhX4c/I/Wlg0jFePx/o7/uZBTx64mWJiMiJaDbcnXPvA/uP0WQy8KxrsBToYGbdAlWgiIh8dYGYc+8O5DfaLvDtExERjwTiPHc7yr6j3rvPzGbRMHVDenp6AH61iIi3Kmvq2F9ezYGKGsoqayirrKWsqoZDR2opr67FOaivd9Q7qHcO5xznDerC0J4dWrSuQIR7AdCz0XYPYPfRGjrn5gBzADIzM3XzVhEJKp8G9f7yakorqimtqOGg7/FARQ0HjlRzsKKGEl+bksNVlFfXfaXfYQZpyXEhEe4LgZvMbD4wGjjonNsTgPcVEQmIssoatheXs724nLziCkrKqz4bbZdWNDzuL6/mSM2XB3VibFvat4umQ3w0nRJiyOgcT6eEWDonxtApIYYO7aJJbhdNUlxbkuIaHhNi2hLVxmhj0MYMMzA72mRH4DUb7mb2PHAukGJmBcAvgGgA59xjwJvABUAuUAF8p6WKFRH5MhXVteQVV7CjpJy8kobH7cXlbCsup6is6nNt27drCOgO8dF0SY7j5K5JdIxvCOlOCTGfPe8YH02H+IZ20VGhdVlQs+HunJvWzOsO+H7AKhIROYaDFTVsKSxjS+Fhtuw73PB832H2Hqr8XLuUxBh6dU7g3AGp9E5NoE9KIn1SE0jvFE9cdJRH1bcezxYOExE5lrp6R87eMjbtPeR7LCNnb9nnQrxddBT90hIZ17czfVITyEhJIKNzAr06x5MUF+1h9d5TuItI0Kipq+fjrSW8tX4Pb2fvo6S8GoCYqDb0TUtkbN/OnNw1iQFdEumflkT3Du1o06Z15rBDjcJdRDxxpLqOvYcq2Xuwkr2HjvBhbgnvbNjHwSM1xMdEMX5gGhMGdeGUk5LJSEkIuTlvryncRaTFHKyoYWvxYbYVlbOtqOFxe3E5ew4e4VBl7efaJsW1ZeKgLkwa0pWzB6RGxLx4S1K4i0jA1NTVs2JHKYtzClm8qZDN+w5/9lrbNkZ653j6pCQwuk8nuiTH0TU5jq7t4+iSHEd6p3hi2mp0HigKdxE5IVW1dSzK3sei7L28v7mIsspaoqOMUb07ccnw7vRPS/rsLBVNrbQehbuIHJddB44wb9kOXlieT/HhalKTYjl/SFfGD0zjjH4pEX+2itcU7iLit8qaOpZuK+G5ZTt5d+M+AMYP7MJVY3txVr8UnbkSRBTuIvKlyqtqWbmzlGXb9vPJ9v2szj9AdV09nRNiuOGcvkwfnU6PjvFelylHoXAXkc+pr3d8kFvMsx/lsWRzEXX1jqg2xpCTkpkxrheje3fmrAEpxLbV2SzBTOEuIkDDaYsvrcjnH0t3kFdSQUpiDDPP7M24fimM7NWRxFjFRSjRX0skwu0+cIRHluTy8opdHKmpY2Svjtw2cQCThnTV6DyEKdxFIlThoUoeWbKVect24nB8a3gPrh7Xi1NOau91aRIACneRCFNyuIrH/ruVuUt3UFPnuGxkD24a309fjIYZhbtIhMgtPMyzH+exYEUBlTV1XDK8O7ee159enRO8Lk1agMJdJIzV1zv+u7mIpz7K4/3NRcREteGiod248dx+9EtL9Lo8aUEKd5EwVFlTx0tZ+Tz5YR7bi8tJS4rl9okDmDYqndSkWK/Lk1agcBcJIwcqqpn78Q6e/iiPkvJqhvbswJ8uH8b5Q7ppUa4Io3AXCQN7Dh7hiQ+28/wnO6moruPck1O54Zy+jO7dqdVuyCzBReEuEsLyist5dMlWXllVQL2Di4eexKyz+zCoW7LXpYnHFO4iIWjzvjJmL87l9TW7aRvVhmmj0pl1dh+dziifUbiLhAjnHFk7Snnig20syt5HfEwUM8/qw8wze5OWHOd1eRJkFO4iQa6ypo6Fa3bz9Id5bNhziOS4ttwyvh/fOaM3HRNivC5PgpTCXSRIlRyu4u//1/AlaWlFDQO6JPLrS0/lkuEnER+jj64cm44QkSC068ARpj++lPz9FUwc3IUZ4zIY26ezznwRvyncRYJM/v4Kpj2+lINHanjphnGM7NXR65IkBCncRYLItqLDXPHEMo7U1DFv5hhO7aEVGuX4KNxFgsSWfWVMf2IZ9fWO568bo3PV5YToemSRILBh9yGmzlkKwPxZCnY5cRq5i3jkUGUNi9bvZeGa3Xy0tYS0pFjmXTeG3ilagldOnMJdpBU551iUvZdXV+1icU4R1bX1pHeK54Zz+nDVmAy6ttfFSBIYfoW7mU0C/gREAU845/63yevpwDNAB1+bO5xzbwa4VpGQ9/u3c5i9eCupSbFcMTqdi4eexLCeHXSKowRcs+FuZlHAbGAiUAAsN7OFzrkNjZrdDbzonHvUzAYDbwIZLVCvSMh6MSuf2Yu3cvnpPfnVpacS1UaBLi3Hny9URwG5zrltzrlqYD4wuUkbB3z6DVB7YHfgShQJfR/lFnPnK+s4q38Kv7xkiIJdWpw/0zLdgfxG2wXA6CZt7gXeNrObgQRgQkCqEwkDuYVlXP+PFfRJTWD2FSOIjtJJatLy/DnKjjbEcE22pwFPO+d6ABcAc83sC+9tZrPMLMvMsoqKir56tSIhpqisimueWk5s2yievOZ0kuOivS5JIoQ/4V4A9Gy03YMvTrtcC7wI4Jz7GIgDUpq+kXNujnMu0zmXmZqaenwVi4SIypo6rns2i+LDVfx9RqbWWpdW5U+4Lwf6m1lvM4sBLgcWNmmzEzgPwMwG0RDuGppLxFq5s5TLHvuYNQUHeHjqcIb27OB1SRJhmp1zd87VmtlNwCIaTnN80jmXbWb3A1nOuYXAD4HHzew2GqZsrnHONZ26EQl7hWWV/PatHF5eWUCX5FgemT6CSUO6el2WRCC/znP3nbP+ZpN99zR6vgE4I7CliYSO6tp6nv5oO39+N5fq2nq+d25fbvpaPxJidZ2geENHnsgJWp1/gB+9tIbcwsOcNzCNuy8arCUExHMKd5HjVFVbx5/f3cKjS7bSNTmOJ6/JZPzALl6XJQIo3EWOy/pdB/nhi2vI2VfGtzN7cPdFg3WaowQVhbvIV1BbV89f3stl9uJcOifG8NQ1p/O1gWlelyXyBQp3ET/V1NVz2wureWPtHi4d3p17v3kK7eM1WpfgpHAX8UN1bT03P7+SRdn7uPOCgcw6u6/XJYkck8JdpBlVtXXc+I+VvLupkF98czDfOaO31yWJNEvhLnIMlTV1XD93Bf/dXMQvLxnCVWN6eV2SiF8U7iJf4kh1HTOfXc5HW0v47f+cytTT070uScRvCneRJmrr6nll1S7+8t4WdpUe4fdThvI/I3t4XZbIV6JwF/GpravntdW7+fN7W9hRUsGQ7sn85tLTOLP/FxY4FQl6CncR4M11e/jdohy2F5czuFsyj1+dyYRBabq3qYQshbtENOccf30vlz+8s5mBXZN47MqRfOOULgp1CXkKd4lY9fWOX725kb//33a+Nbw7v51ymm6BJ2FD4S4RqbaunjteWceCFQVcMy6Dey4aTBvdtFrCiMJdIk5lTR23PL+Ktzfs47YJA7jlvH6ahpGwo3CXiFJeVct1z2bx0dYS7v3mYK7R1aYSphTuEjGOVNfx3aeXk7WjlIemDuXS4Tp3XcKXwl0iQmVNHbPmZrE8bz8PTR3G5GHdvS5JpEUp3CXsVdXW8b1/rOD/cov53ZShCnaJCDrvS8JaTV09N81bxeKcIn51yalM0TICEiEU7hK2auvq+cH81byzYR/3XXwK00dr4S+JHAp3CUv19Y6fvLyWf63bw10XDGLGuAyvSxJpVQp3CTvOOe57PZtXVu7i9okDuO7sPl6XJNLqFO4Sdv74zmae+XgH153Vm5vH9/O6HBFPKNwlrDz+/jb+8l4uUzN7cucFg3TlqUQshbuEjfmf7ORXb27kwlO78etvnapgl4imcJew8Mba3fzs1XWcMyCVh6YOI0qLgEmEU7hLyFtXcJDbX1hDZq+OPHblSGLa6rAW0adAQtrBIzXcOG8FKYkxzLkqk3YxUV6XJBIUtPyAhCznHD9ZsIY9Byp54fqxdEyI8bokkaDh18jdzCaZWY6Z5ZrZHV/S5ttmtsHMss1sXmDLFPmipz7MY1H2Pn46aSAje3X0uhyRoNLsyN3MooDZwESgAFhuZgudcxsatekP/Aw4wzlXamZpLVWwCMCqnaX85q2NTBjUhZlnaU12kab8GbmPAnKdc9ucc9XAfGBykzbXAbOdc6UAzrnCwJYp8v8dqKjmpnmrSEuK4w+XDdUpjyJH4U+4dwfyG20X+PY1NgAYYGYfmtlSM5sUqAJFGnPO8aOX1lBYVsnsK0bQPj7a65JEgpI/X6gebVjkjvI+/YFzgR7AB2Y2xDl34HNvZDYLmAWQnq4V+uSr2XeokjteXsvinCLuuWgww3p28LokkaDlz8i9AOjZaLsHsPsobV5zztU457YDOTSE/ec45+Y45zKdc5mpqanHW7NEGOccr63exdcfep+PtzXc+/Q7Z2R4XZZIUPNn5L4c6G9mvYFdwOXA9CZt/glMA542sxQapmm2BbJQiUzFh6u4+9X1/Dt7LyPSO/D7y4bSJzXR67JEgl6z4e6cqzWzm4BFQBTwpHMu28zuB7Kccwt9r33dzDYAdcCPnXMlLVm4hL8Pc4u55flVlFXWcsf5A7nurD5aVkDET+Zc0+nz1pGZmemysrI8+d0S/PaXVzPhj/+lU0IMj1wxggFdkrwuSSQomNkK51xmc+10haoEpftfz6assob5s8Yo2EWOg9aWkaCzeFMh/1y9mxvP7adgFzlOCncJKoerarnr1XX0T0vkxq/19bockZClaRkJKg/+exN7DlWy4IZxxLbVCo8ix0sjdwkaWXn7mbt0BzPGZmghMJETpHCXoFBZU8dPX17LSe3b8eNvnOx1OSIhT9MyEhRmL85la1E5z3x3FAmxOixFTpRG7uK5D3OLeWTJVr41ojvnDNCyFCKBoHAXT20vLufG51bSLzWR+ycP8bockbChcBfPHKqsYeYzy2lj8MSMTBI1HSMSMPo0iSfq6h23PL+KHSUV/GPmaHp2ive6JJGwonAXT/z235tYklPEry4dwpg+nb0uRyTsaFpGWt2CFQXMeX8bV4/txRWje3ldjkhYUrhLq1pbcIA7X1nHuL6d+flFg70uRyRsKdyl1ZRX1XLr/NWkJMYwe/oIoqN0+Im0FM25S6t54F8byCsp5/nrxtAxIcbrckTCmoZO0ioWZe/l+U/yuf7svvoCVaQVKNylxRUequSOl9cypHsyt08c4HU5IhFB4S4tqr7e8aMFazlSU8fDU4cT01aHnEhr0CdNWtQzH+fx/uYi7rpwMP3SEr0uRyRiKNylxWzeV8Zv3trEeQPTuHJ0utfliEQUhbu0iNzCMmY8+QnJcW357ZTTMDOvSxKJKAp3CbiVO0uZ8tjH1NQ5nvnuKFISY70uSSTi6Dx3CajFmwr53nMr6JIcx9zvjia9sxYEE/GCwl0C5pWVBfx4wVoGdUviqWtGkZqkEbuIVxTuEhBPfLCNB/61kXF9O/O3q0aSFBftdUkiEU3hLifsjbW7eeBfG7ng1K48NHUYsW2jvC5JJOIp3OWEbN5Xxk8WrGVkr466SEkkiOiTKMftUGUN189dQUJsWx65YoSCXSSI6NMox6W+3nH7C2vI31/BI1eMoEtynNcliUgjCnc5LrMX5/Kfjfu4+8JBnJ7RyetyRKQJv8LdzCaZWY6Z5ZrZHcdoN8XMnJllBq5ECTaLcwr54382c+nw7swYl+F1OSJyFM2Gu5lFAbOB84HBwDQz+8L90cwsCbgFWBboIiV45BYe5gfzVzOwazK/vvRULSsgEqT8GbmPAnKdc9ucc9XAfGDyUdr9EngQqAxgfRJEVu0s5bLHPiI6yvjblSNpF6NTHkWClT/h3h3Ib7Rd4Nv3GTMbDvR0zr0RwNokiCzeVMj0x5eR3C6al783TssKiAQ5f85zP9r/d7vPXjRrAzwEXNPsG5nNAmYBpKdrCdhQ8VJWPne8sk7LCoiEEH9G7gVAz0bbPYDdjbaTgCHAEjPLA8YAC4/2papzbo5zLtM5l5mamnr8VUurcM7xyJJcfrxgLWP7dGb+rLEKdpEQ4c/IfTnQ38x6A7uAy4Hpn77onDsIpHy6bWZLgB8557ICW6q0tt+/ncPsxVu5eOhJ/P6yobpISSSENPtpdc7VAjcBi4CNwIvOuWwzu9/MLm7pAsUbL2XlM3vxVqaN6snDU4cp2EVCjF9ryzjn3gTebLLvni9pe+6JlyVeWrFjP3e9up4z+nXm/slDaNNGpzuKhBoNx+Rzdh04wvVzV3BShzhmTx9BdJQOEZFQpFUh5TPlVbXMfCaLqtp65s86nQ7xMV6XJCLHScMyARoWAvvhi2vI2XuIv0wbTr+0RK9LEpEToHAXAB7+z2b+nb2XOy8YxLknp3ldjoicIIW78OzHefz5vVy+ndmDa8/s7XU5IhIACvcI92JWPve8ls3EwV34lRYCEwkbCvcI9vqa3dzx8lrO6p/CX6cP15kxImFEn+YI9c6Gfdz2wmoyMzox56pM3dRaJMwo3CPQ+5uL+P5zKzmle3uevOZ0Ld0rEoYU7hFmXcFBZs3Nom9aIs9+ZxSJsbrUQSQcKdwjSG1dPT95eS0d2sUw99pRtI+P9rokEWkhGrZFkKc+zGPjnkM8duVIUhK1dK9IONPIPUIUlFbwx3c2M2FQF75xShevyxGRFqZwjwDOOe55LRszuG/yKTqXXSQCKNwjwL/X7+W9TYXcPnEA3Tu087ocEWkFCvcwd6iyhl8szGZwt2SuGZfhdTki0kr0hWqY+8OiHIoOV/H41Zm01RWoIhFDn/Ywtib/AM8u3cGMsRkM7dnB63JEpBUp3MNUUVkVt8xfRVpSLD/8+gCvyxGRVqZpmTBUVlnDNU99QuGhKp67bjRJcbpYSSTSaOQeZipr6pj17Apy9pbxyJUjGJHe0euSRMQDGrmHkbp6x20vrObjbSU8PHUYX9MdlUQilkbuYcI5x89fW89b6/dy94WDuGR4d69LEhEPKdzDxEP/2cK8ZTu54Zy+zDyrj9fliIjHNC0T4pxzPLgoh0eXbOWykT346aSTvS5JRIKAwj2E1dU77np1HfOX5zN9dDq/nDxE68aICKBwD1lVtXX8YP5q3lq/l5vH9+P2iQMU7CLyGYV7CDpcVcv1c7P4MLeEn180mGvP7O11SSISZBTuIaa0vJoZT31C9u5D/PHbQ/nWiB5elyQiQUjhHkKqa+u54R8r2LS3jDlXjeS8QbrphogcnU6FDBHOOe59PZtl2/fzuymnKdhF5Jj8Cnczm2RmOWaWa2Z3HOX1281sg5mtNbN3zaxX4EuNbHOX7mDesp1879y+TB6mC5RE5NiaDXcziwJmA+cDg4FpZja4SbNVQKZz7jRgAfBgoAuNZB/mFnPf6xuYMCiNH39d57GLSPP8GbmPAnKdc9ucc9XAfGBy4wbOucXOuQrf5lJA3/IFyPbicm58biV9UxN4+PLhtGmj0x1FpHn+hHt3IL/RdoFv35e5FnjrRIqSBocqa5j5zHLaGDxx9ekkxur7bxHxjz9pcbShojtqQ7MrgUzgnC95fRYwCyA9Pd3PEiNTdW09339uJTtKKph77WjSO8d7XZKIhBB/Ru4FQM9G2z2A3U0bmdkE4C7gYudc1dHeyDk3xzmX6ZzLTE1NPZ56I8KnS/d+sKWYX196KmP7dva6JBEJMf6E+3Kgv5n1NrMY4HJgYeMGZjYc+BsNwV4Y+DIjh3OOO19Zx7/W7eHuCwfx7dN7Nv8fiYg00Wy4O+dqgZuARcBG4EXnXLaZ3W9mF/ua/Q5IBF4ys9VmtvBL3k6OwTnHb97axAtZ+dw8vp+W7hWR4+bXN3TOuTeBN5vsu6fR8wkBrisiPbJkK3Pe38aMsb24faJuai0ix09XqAaJuUt38LtFOVw6vDu/+OYpWuFRRE6Iwj0ILMreyz2vrWfCoDQenHKazmUXkROmcPfY2oID3Dp/FUN7dOCv00cQHaU/iYicOCWJh3YdOMK1z2SRkhjL41dnEhcd5XVJIhImdMmjR8oqa/juU8uprK5j3szRpCbFel2SiIQRhbsHauvquWneKnKLDvP0d06nf5ckr0sSkTCjaZlW9um67P/dXMQDlwzhrP66UldEAk8j91ZUUV3LA//ayLxlO7n+nD5MG6X1dUSkZSjcW8naggP8YP5qtpeUc/05ffjpNwZ6XZKIhDGFewurq3c8uiSXh/+zhdSkWJ6bOZpxfVO8LktEwpzCvQXl76/gthdWk7WjlG8OPYkHJg+hfXy012WJSARQuLeQVTtLufaZLGpq63l46jAmDztJSwqISKtRuLeAdzfu4/vzVpKWFMcz3xtF75QEr0sSkQijcA+w+Z/s5M5X1zGke3v+PuN0XZwkIp5QuAeIc46H/7OFP727hXNPTmX29BEk6J6nIuIRpU8AVNXWcc8/s3khK5/LRvbg1986VQuAiYinFO4naHtxOTfNW0n27kPcPL4ft08coC9ORcRzCvcT8OqqAu5+dT3Rbdvw+NWZTBzcxeuSREQAhftxKa+q5eevreeVlbsYldGJP00bRrf27bwuS0TkMwr3r2jlzlJ+9OIatpeUc+t5/bl5fD/aan5dRIKMwt1PpeXVPLhoE89/kk/X5DjmzRzD2L6dvS5LROSoFO7NqK93LFhZwP++tYmDR2q47qze3DphAIk6zVFEgpgS6hjW7zrIvQuzydpRSmavjjxw6RAGdk32uiwRkWYp3I9i5c5SZr+Xy7ubCukYH82DU05jyogetGmjUxxFJDQo3H2cc3y0tYS/vpfLx9tK6BAfze0TBzBjbIZWchSRkKNwp+FGGvcuzGblzgOkJcVy94WDmDYqXcsHiEjIiuj0Kqus4Q9vb+bZj/PonBjLA5cMYcrIHsRFR3ldmojICYnIcHfO8db6vdz3ejaFZVVcNaYXP/rGySTHafpFRMJDRIW7c45V+Qf463u5vLepkMHdkvnbVZkM69nB69JERAIqIsI9Z28ZC9fsYuGa3eTvP0J8TBR3XziIa8Zl6OpSEQlLYRnudfWOdbsOsiSnkLfW7SVnXxltDM7ol8It4/vzjSFdNQUjImHNr3A3s0nAn4Ao4Ann3P82eT0WeBYYCZQAU51zeYEt9dgKyyr5YHMx/91cxAdbiiitqMEMRqR35L6LT+GCU7vprkgiEjGaDXcziwJmAxOBAmC5mS10zm1o1OxaoNQ518/MLgd+C0xtiYKhYe58R0kFn+TtJytvP8vzStleXA5ASmIsXxuYxjkDUjmrfyqdEmJaqgwRkaDlz8h9FJDrnNsGYGbzgclA43CfDNzre74A+KuZmXPOBbBWoOEepX94ZzNFZVUAdIiPJrNXRy4/vSdn9EthcLdkXUkqIhHPn3DvDuQ32i4ARn9ZG+dcrZkdBDoDxYEosrG05FjO7JdCZkZHRmV0om9qosJcRKQJf8L9aMnZdETuTxvMbBYwCyA9Pd2PX/1F4wd2YfxA3fFIRORY/DkPsADo2Wi7B7D7y9qYWVugPbC/6Rs55+Y45zKdc5mpqanHV7GIiDTLn3BfDvQ3s95mFgNcDixs0mYhMMP3fArwXkvMt4uIiH+anZbxzaHfBCyi4VTIJ51z2WZ2P5DlnFsI/B2Ya2a5NIzYL2/JokVE5Nj8Os/dOfcm8GaTffc0el4JXBbY0kRE5Hjp2nsRkTCkcBcRCUMKdxGRMKRwFxEJQ+bVGYtmVgTsaLI7hRa4qtVj6lPoCMd+hWOfIDz75W+fejnnmr1QyLNwPxozy3LOZXpdRyCpT6EjHPsVjn2C8OxXoPukaRkRkTCkcBcRCUPBFu5zvC6gBahPoSMc+xWOfYLw7FdA+xRUc+4iIhIYwTZyFxGRAAiKcDezSWaWY2a5ZnaH1/UcLzN70swKzWx9o32dzOwdM9vie+zoZY1flZn1NLPFZrbRzLLN7Fbf/pDtl5nFmdknZrbG16f7fPt7m9kyX59e8K2CGlLMLMrMVpnZG77tcOhTnpmtM7PVZpbl2xeyxx+AmXUwswVmtsn32Rob6D55Hu6N7tF6PjAYmGZmg72t6rg9DUxqsu8O4F3nXH/gXd92KKkFfuicGwSMAb7v+/uEcr+qgPHOuaHAMGCSmY2h4d6/D/n6VErDvYFDza3Axkbb4dAngK8554Y1OlUwlI8/gD8B/3bODQSG0vA3C2yfnHOe/gBjgUWNtn8G/Mzruk6gPxnA+kbbOUA33/NuQI7XNZ5g/16j4WbpYdEvIB5YScOtI4uBtr79nzsuQ+GHhhvpvAuMB96g4Q5pId0nX915QEqTfSF7/AHJwHZ833m2VJ88H7lz9Hu0dveolpbQxTm3B8D3mOZxPcfNzDKA4cAyQrxfvumL1UAh8A6wFTjgnKv1NQnF4/Bh4CdAvW+7M6HfJ2i4ZefbZrbCd6tOCO3jrw9QBDzlm0J7wswSCHCfgiHc/br/qnjLzBKBl4EfOOcOeV3PiXLO1TnnhtEw2h0FDDpas9at6viZ2UVAoXNuRePdR2kaMn1q5Azn3Agapm6/b2Zne13QCWoLjAAedc4NB8ppgWmlYAg3W6iDAAABd0lEQVR3f+7RGsr2mVk3AN9jocf1fGVmFk1DsD/nnHvFtzvk+wXgnDsALKHh+4QOvnsAQ+gdh2cAF5tZHjCfhqmZhwntPgHgnNvteywEXqXhH+NQPv4KgALn3DLf9gIawj6gfQqGcPfnHq2hrPH9ZWfQMGcdMszMaLiN4kbn3B8bvRSy/TKzVDPr4HveDphAwxdai2m4BzCEWJ+ccz9zzvVwzmXQ8Bl6zzl3BSHcJwAzSzCzpE+fA18H1hPCx59zbi+Qb2Yn+3adB2wg0H3y+ssF35cHFwCbaZj3vMvrek6gH88De4AaGv51vpaGec93gS2+x05e1/kV+3QmDf8rvxZY7fu5IJT7BZwGrPL1aT1wj29/H+ATIBd4CYj1utbj7N+5wBvh0Cdf/Wt8P9mf5kMoH3+++ocBWb5j8J9Ax0D3SVeoioiEoWCYlhERkQBTuIuIhCGFu4hIGFK4i4iEIYW7iEgYUriLiIQhhbuISBhSuIuIhKH/B+SFU9mV5c6fAAAAAElFTkSuQmCC\n",
-      "text/plain": [
-       "<Figure size 432x288 with 1 Axes>"
-      ]
-     },
-     "metadata": {
-      "needs_background": "light"
-     },
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
+    "%matplotlib inline\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "def plot(data):\n",
@@ -281,7 +274,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/augsburg/exercises/BirthdayProblem/BirthdayProblem.ipynb
+++ b/augsburg/exercises/BirthdayProblem/BirthdayProblem.ipynb
@@ -109,9 +109,10 @@
    "outputs": [],
    "source": [
     "random.seed(42)\n",
-    "equal_birthdays(10)\n",
+    "equal_birthdays_1(10)\n",
     "random_number = random.randint(1, 100000)\n",
-    "assert random_number != 3479, 'It looks like you are generating twice as many random numbers as needed.'\n",
+    "assert random_number != 3479, ('It looks like you are generating twice as many random numbers as needed. '\n",
+    "                               'Try to avoid this.')\n",
     "assert random_number == 11396, 'The number of dates generated does not seem to fit the number of persons.'\n",
     "for seed, result in ((42, False), (192347, True)):\n",
     "    random.seed(seed)\n",
@@ -202,9 +203,8 @@
    },
    "outputs": [],
    "source": [
-    "random.seed(42)\n",
-    "for npersons, result in ((10, 0.11705), (20, 0.41171), (30, 0.70778)):\n",
-    "    assert abs(probability_equal_birthdays(npersons, 100000)-result) < 0.0001, (\n",
+    "for npersons, result in ((10, 0.116948), (20, 0.411438), (30, 0.706316)):\n",
+    "    assert abs(probability_equal_birthdays(npersons, 100000)-result) < 0.01, (\n",
     "        'Your function appears to return an incorrect result.')"
    ]
   },
@@ -230,7 +230,7 @@
    },
    "outputs": [],
    "source": [
-    "%matplotlib inline\n",
+    "%matplotlib notebook\n",
     "import matplotlib.pyplot as plt\n",
     "\n",
     "def plot(data):\n",
@@ -248,6 +248,13 @@
     "    coincidencelist.append((npersons, probability_equal_birthdays(npersons)))\n",
     "### END SOLUTION\n",
     "plot(coincidencelist)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you would like to zoom into the figure to determine where a threshold of 50% is reached, try replacing in the above code cell ``%matplotlib inline`` by ``%matplotlib notebook``. If the figure does not display properly, try restarting the kernel in the dashboard and run all code cells. In the icons below the figure, click on the fifth icon from the left. You can then choose an area of the figure which will be magnified."
    ]
   },
   {

--- a/augsburg/exercises/BirthdayProblem/~ListsAndSets.ipynb
+++ b/augsburg/exercises/BirthdayProblem/~ListsAndSets.ipynb
@@ -62,7 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%timeit nlen in x"
+    "%timeit nlen-1 in x"
    ]
   },
   {
@@ -71,7 +71,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "%timeit nlen+1 in x"
+    "%timeit nlen in x"
    ]
   },
   {
@@ -155,6 +155,13 @@
    "source": [
     "%timeit nlen+1 in x"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "How can you make use of sets to check for the presence of birthday coincidences?"
+   ]
   }
  ],
  "metadata": {
@@ -173,7 +180,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
In the exercise session, it turned out that tests can fail even though the student's program is correct. The reason is that in order to generate birthdays, one can either draw a random number out of 365 different choices or draw two random numbers per birthday corresponding to month and day. The latter wastes compute time so that the first solution is preferable. The tests now check for the number of random numbers generated and provide corresponding messages. This PR thus provides a version where the number of generated random numbers is checked before further tests are done.