### PR TITLE
small correction to docstring

### DIFF
--- a/augsburg/exercises/Pi/Pi.ipynb
+++ b/augsburg/exercises/Pi/Pi.ipynb
@@ -560,7 +560,7 @@
     "def pi_agm_int(scale):\n",
     "    \"\"\"determine pi by means of the arithmetic-geometric mean\n",
     "       using integer arithmetic after expanding the fraction by\n",
-    "       scale\n",
+    "       scale**2\n",
     "       \n",
     "       scale: numerator and denominator are expanded by the\n",
     "              square of this parameter, typically a power of ten\n",


### PR DESCRIPTION
This PR makes a small correction to the docstring to clarify the meaning of the variable `scale`.