### PR TITLE
explanation extended and corrected

### DIFF
--- a/augsburg/exercises/GameOfLife/~Convolution.ipynb
+++ b/augsburg/exercises/GameOfLife/~Convolution.ipynb
@@ -45,7 +45,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As mentioned above, elements beyond the array boundaries are set to zero by `convolve`. The two-dimensional version `convolve2d` allows for two different behaviors. `mode='fill'` sets the missing values to `fillvalue` which by default is zero. `mode='fill'` thus behaves in the same way as `convolve`. Another choice is `mode='wrap'` which uses periodic boundary conditions. This is a sensible choice in the game of life by which boundary effects can be avoided."
+    "As mentioned above, elements beyond the array boundaries are set to zero by `convolve`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There is also a two-dimensional convolution provided by `scipy.signal.convolve2d`. In the context of the game of life, it is appropriate to use `mode='same'` as in the previous one-dimensional example. `convolve2d` offers different ways to treat the boundaries, two of which are of interest to us.\n",
+    "\n",
+    "`boundary='fill'` will fill missing values outside the array with `fillvalue` which by default equals zero. Another choice is `boundary='wrap'` which amounts to applying periodic boundary conditions. Applied to our problem, this choice implies evolving the game of life on a toroidal lattice. In this way, boundary effects can be avoided."
    ]
   }
  ],
@@ -65,7 +74,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR extends and corrects the explanation of `scipy.signal.convolve2d` in the accompanying notebook to the game of life exercise.