### PR TITLE
numpy version unconstrained

### DIFF
--- a/augsburg/notebooks/generalrelativity/requirements.txt
+++ b/augsburg/notebooks/generalrelativity/requirements.txt
@@ -1,6 +1,6 @@
 GraviPy==0.2.0
 jupyter==1.0.0
 K3D==2.7.0
-numpy==1.21
+numpy
 scipy==1.3.3
 sympy==1.4

--- a/augsburg/notebooks/generalrelativity/requirements.txt
+++ b/augsburg/notebooks/generalrelativity/requirements.txt
@@ -1,6 +1,6 @@
 GraviPy==0.2.0
 jupyter==1.0.0
 K3D==2.7.0
-numpy==1.17.4
+numpy==1.21
 scipy==1.3.3
 sympy==1.4


### PR DESCRIPTION
Github dependabot indicated vulnerabilities in Numpy >= 1.9.0 < 1.21 and also in 1.22. It appears reasonable to just use the latest version. 